### PR TITLE
Change tabbrowser-arrowscrollbox from class to id

### DIFF
--- a/src/browser.css
+++ b/src/browser.css
@@ -12,7 +12,7 @@
 
 /********** Tabs **********/
 
-#tabbrowser-tabs, .tabbrowser-arrowscrollbox {
+#tabbrowser-tabs, #tabbrowser-arrowscrollbox {
     /* Otherwise, a single tab row is too high */
     min-height: 0 !important;
 }
@@ -33,26 +33,26 @@ toolbarbutton#tabs-newtab-button {
     visibility: visible !important;
 }
 
-#tabbrowser-tabs .tabbrowser-arrowscrollbox {
+#tabbrowser-tabs #tabbrowser-arrowscrollbox {
     /* Required, so the scrollbox always shows all tabs */
     display: block;
 }
 
-.tabbrowser-arrowscrollbox::part(scrollbutton-up),
-.tabbrowser-arrowscrollbox::part(scrollbutton-down) {
+#tabbrowser-arrowscrollbox::part(scrollbutton-up),
+#tabbrowser-arrowscrollbox::part(scrollbutton-down) {
     /* Doesn't make sense to scroll through multi-row tabs since they are all
      * visible */
     display: none !important;
 }
 
-.tabbrowser-arrowscrollbox::part(scrollbox) {
+#tabbrowser-arrowscrollbox::part(scrollbox) {
     width: 100% !important;
     display: flex !important;
     flex-wrap: wrap !important;
 }
 
-.tabbrowser-arrowscrollbox::part(arrowscrollbox-overflow-start-indicator),
-.tabbrowser-arrowscrollbox::part(arrowscrollbox-overflow-end-indicator) {
+#tabbrowser-arrowscrollbox::part(arrowscrollbox-overflow-start-indicator),
+#tabbrowser-arrowscrollbox::part(arrowscrollbox-overflow-end-indicator) {
     /* With multi-row tabs, we don't want overflow indicators */
     display: none;
 }


### PR DESCRIPTION
It appears that the arrowbox is now id tabbrowser-arrowscrollbox instead of class.  Change CSS to accommodate and resolve #53 