### PR TITLE
Fix tab bar height bug in Firefox 107.0a1

### DIFF
--- a/src/browser.css
+++ b/src/browser.css
@@ -25,6 +25,8 @@
 #tabbrowser-arrowscrollbox::part(scrollbox-clip) {
     /* Required, so the scrollbox always shows all tabs */
     display: block !important;
+    /* Fix vertical grow of container (GH-96) */
+    contain: none !important;
 }
 
 #tabbrowser-arrowscrollbox::part(scrollbutton-up),


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/73892113/195986977-aec86495-f854-4c9d-ab1e-1705d1407636.png)

Firefox 107.0a1 added new CSS to Firefox that broke Paxmod. This patch will fix that problem.

Caused CSS
```
#tabbrowser-arrowscrollbox::part(scrollbox-clip) {
  contain: inline-size;
}
```
After fix.
```
#tabbrowser-arrowscrollbox::part(scrollbox-clip) {
  contain: unset;
}
```

![image](https://user-images.githubusercontent.com/73892113/195987089-ea23103a-3f11-4a47-bbc7-f6e7c2de21cd.png)


PS: Thanks for maintaining a great addon.